### PR TITLE
Add HTTPS support

### DIFF
--- a/lib/node-home-assistant.js
+++ b/lib/node-home-assistant.js
@@ -3,6 +3,8 @@ const debug    = require('debug')('home-assistant');
 const HaEvents = require('./ha-events');
 const HaApi    = require('./ha-api');
 
+require('ssl-root-cas').inject();
+
 const DEFAULTS = {
     baseUrl: null,
     apiPass: null,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "merge": "^1.2.0",
     "object-merge": "^2.5.1",
     "pino": "^4.10.2",
+    "ssl-root-cas": "^1.2.5",
     "timeago.js": "^3.0.2",
     "tty-table": "^2.5.5"
   },


### PR DESCRIPTION
This library currently does not support connecting to Home Assistant when using HTTPS (giving the very generic error "Connection to home assistant could not be established with config").

This pull request loads the standard CA root certificates so that properly signed certificates can be used to connect to Home Assistant. It doesn't currently address self-signed certificates (this should probably be an option as well, but it would also need to have an upstream option in `node-red-contrib-home-assistant`.)